### PR TITLE
[fix] don't replace git_url when it is valid.

### DIFF
--- a/tests/fetcher/test_external_ressources.py
+++ b/tests/fetcher/test_external_ressources.py
@@ -92,6 +92,7 @@ def fake_searxstatisticsresult(fake_httpserver):
             'status_code': 200,
             'error': None
         },
+        'git_url': 'https://github.com/searx/searx',
         'version': '0.15.0',
         'timing': {
             'initial': 200


### PR DESCRIPTION
valid = the static files downloaded by the browser belong to the git_url.

---

If a fork contains exactly the same static files(*),
searxstats don't know which fork to pick.

(*) more precisly: the browser fetchs some static files.
searxstats get the commits related to these files, then the forks.

This commit give priority to the declared git_url,
so the git_url is not replaced.

Partial fix of #76 : it fixes GIT_URL for https://darmarit.org/searx/ instance.
