### PR TITLE
[fix] fork: more reliable

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -233,6 +233,7 @@
             <p>When the page is loaded by Firefox, are the scripts well-known ?</p>
             <ul>
               <li>V - Vanilla instance: all static files comes from the searx git repository.</li>
+              <li>F - Fork: all static files comes from a fork of searx</li>
               <li>C - Some static files have been modified, but the Javascripts comes from the searx git repository.</li>
               <li>Cjs - Some static files have been modified including Javascript files.</li>
               <li>E - The instance includes file from another domain.</li>

--- a/searxstats/common/askpassword.sh
+++ b/searxstats/common/askpassword.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# when git asks for username & password, provide fake answers
+# the repository must be public
+echo 'dummy'

--- a/searxstats/config.py
+++ b/searxstats/config.py
@@ -64,6 +64,14 @@ MMDB_FILENAME = os.environ.get("MMDB_FILENAME")
 DEBIAN_GIT_URL = 'https://salsa.debian.org/debian/searx'
 DEBIAN_SOURCE_PACKAGE_NAMES = ['searx', 'twitter-bootstrap3', 'jquery', 'leaflet', 'requirejs', 'typeahead.js']
 
+#
+FORKS = [
+    'https://github.com/searx/searx',
+    'https://github.com/searxng/searxng',
+    'https://salsa.debian.org/debian/searx',
+    'https://gitlab.e.foundation/e/cloud/my-spot',
+]
+
 
 def set_cache_directory(directory):
     global CACHE_DIRECTORY  # pylint: disable=global-statement

--- a/searxstats/data/fetch_git.py
+++ b/searxstats/data/fetch_git.py
@@ -44,7 +44,7 @@ def get_content_list_per_commit_iterator(repo_directory, repo, commit_list):
             content_for_commit.add(content_hash)
             seen_content_hashes.add(content_hash)
         # yield
-        yield str(commit.hexsha), content_for_commit
+        yield str(commit.hexsha), commit.authored_date, content_for_commit
         # output
         if count % 50 == 0 or (commit_count - count) < 5 or count == 1:
             print('commit {:4} of {:4}: {:4} different hashes'.format(
@@ -94,8 +94,8 @@ def fetch_hashes_from_git_url(git_url=None):
         print('  {:5} new commit(s)'.format(len(new_commit_list)))
 
         commit_iterator = get_content_list_per_commit_iterator(repo_directory, repo, new_commit_list)
-        for commit_sha, content_hash_list in commit_iterator:
+        for commit_sha, commit_date, content_hash_list in commit_iterator:
             # one SQL transaction per commit
             with new_session(bind=connection) as session:
-                insert_commit(session, git_url, commit_sha, content_hash_list)
+                insert_commit(session, git_url, commit_sha, commit_date, content_hash_list)
                 session.commit()

--- a/searxstats/data/update.py
+++ b/searxstats/data/update.py
@@ -24,7 +24,7 @@ def insert_content(session, commit_obj, content_hash_list):
                         for content_id in content_id_list])
 
 
-def insert_commit(session, repo_url, commit_sha, content_hash_list):
+def insert_commit(session, repo_url, commit_sha, commit_date, content_hash_list):
     # get fork_obj
     fork_obj = session.query(Fork)\
                         .where(Fork.git_url == repo_url)\
@@ -42,7 +42,7 @@ def insert_commit(session, repo_url, commit_sha, content_hash_list):
                         .scalar()
     if not commit_obj:
         is_new_commit = True
-        commit_obj = Commit(sha=commit_sha, forks=[fork_obj])
+        commit_obj = Commit(sha=commit_sha, date=commit_date, forks=[fork_obj])
         session.add(commit_obj)
     elif fork_obj not in commit_obj.forks:
         commit_obj.forks.append(fork_obj)

--- a/searxstats/database.py
+++ b/searxstats/database.py
@@ -39,6 +39,7 @@ class Commit(Base):
 
     id = Column(Integer, primary_key=True)
     sha = Column(String, nullable=False)
+    date = Column(Integer, nullable=False)
     contents = relationship("Content",
                             secondary=commit_content_table,
                             back_populates="commits",


### PR DESCRIPTION
* if a git repository asks for a password provide a dummy answer
* common/git_tool.py:
  * git checkout the existing branch instead of master (deal with the main branch)
  * catch all exceptions, so the repository is always updated
    (before the code crashes, and the repository was not updated)
* database: store author commit date, so it is possible to get the oldest commit for a hash
* some forks are always fetched: even if the /config API endpoint returns an empty GIT_URL,
  searxstats can detect these forks (see searx/config.py)
* searxstats/fetcher/external_ressources.py:
  * replace git_url by the oldest forks which own the static files

close #76
close #78