### PR TITLE
[mod] HTML grade: display SearXNG as vanilla in addtition to searx

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -349,17 +349,15 @@ Vue.component('url-component', {
                 }
                 for (const [altUrl, altComment] of Object.entries(this.alternativeurls)) {
                     tooltipLines.push(h('tr', [
-                        h('td', altUrl),
-                        h('td', altComment)
+                        h('td', altComment),
+                        h('td', altUrl)
                     ]));
                 }
             }
-            if (this.git_url != 'https://github.com/searx/searx') {
-                tooltipLines.push(h('tr', [
-                    h('td', [ h('a', { attrs: { href: this.git_url } }, this.git_url) ]),
-                    h('td', 'Fork'),
-                ]));
-            }
+            tooltipLines.push(h('tr', [
+                h('td', 'Git URL'),
+                h('td', [ h('a', { attrs: { href: this.git_url } }, this.git_url) ]),
+            ]));
             const ahrefElement = h('a', { attrs: {  href: this.url } }, this.url);
             if (tooltipLines.length > 0) {
                 return createTooltip(h,
@@ -551,13 +549,11 @@ Vue.component('html-component', {
                             h('td', { attrs: attrs }, ''),
                         ]));
                     }
-                    if (this.git_url != 'https://github.com/searx/searx') {
-                        r.push(h('tr', [
-                            h('td', { attrs: attrs }, 'Fork'),
-                            h('td', { attrs: attrs }, [ h('a', { attrs: { href: this.git_url } }, this.git_url) ]),
-                            h('td', { attrs: attrs }, ''),
-                        ]));
-                    }
+                    r.push(h('tr', [
+                        h('td', { attrs: attrs }, 'Git URL'),
+                        h('td', { attrs: attrs }, [ h('a', { attrs: { href: this.git_url } }, this.git_url) ]),
+                        h('td', { attrs: attrs }, ''),
+                    ]));
                     // inline scripts
                     let unknownCountMin = 1000000;
                     let unknownInlineScriptCount = 0;

--- a/searxstats/config.py
+++ b/searxstats/config.py
@@ -51,6 +51,7 @@ SEARXINSTANCES_GIT_DIRECTORY = 'searxinstances-git'
 
 # Git URL of searx (to fetch static file content hashes)
 SEARX_GIT_REPOSITORY = 'https://github.com/searx/searx'
+SEARXNG_GIT_REPOSITORY = 'https://github.com/searxng/searxng'
 
 SEARXINSTANCES_GIT_REPOSITORY = 'https://github.com/searx/searx-instances'
 

--- a/searxstats/fetcher/basic.py
+++ b/searxstats/fetcher/basic.py
@@ -13,7 +13,7 @@ from searxstats.common.ssl_info import get_ssl_info
 from searxstats.common.memoize import MemoizeToDisk
 from searxstats.common.response_time import ResponseTimeStats
 from searxstats.data import get_fork_list
-from searxstats.config import DEFAULT_HEADERS
+from searxstats.config import DEFAULT_HEADERS, SEARX_GIT_REPOSITORY
 
 
 # in a HTML page produced by searx, regex to find the searx version
@@ -75,7 +75,7 @@ async def set_searx_version(detail, git_url, session, response_url, response):
     if git_url:
         git_url = await resolve_https_redirect(session, git_url)
     else:
-        git_url = 'https://github.com/searx/searx'
+        git_url = SEARX_GIT_REPOSITORY
     detail['git_url'] = git_url
 
 

--- a/searxstats/fetcher/external_ressources.py
+++ b/searxstats/fetcher/external_ressources.py
@@ -7,7 +7,7 @@ import sys
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
 
-from searxstats.config import SEARX_GIT_REPOSITORY, FORKS, \
+from searxstats.config import SEARX_GIT_REPOSITORY, SEARXNG_GIT_REPOSITORY, FORKS, \
                               BROWSER_LOAD_TIMEOUT, TOR_SOCKS_PROXY_HOST, TOR_SOCKS_PROXY_PORT,\
                               get_geckodriver_file_name
 from searxstats.data import get_repositories_for_content_sha, is_wellknown_content_sha
@@ -138,7 +138,10 @@ def replace_hash_by_hashref(result, hashes, forks):
                         repo_url_list = get_repositories_for_content_sha(ressource_hash)
                         if not repo_url_list:
                             new_hash_desc['unknown'] = True
-                        elif SEARX_GIT_REPOSITORY not in repo_url_list:
+                        elif (
+                                SEARX_GIT_REPOSITORY not in repo_url_list
+                                and SEARXNG_GIT_REPOSITORY not in repo_url_list
+                        ):
                             new_hash_desc['forks'] = [forks.index(f) for f in repo_url_list]
                     # ressource_hash first seen for the whole run
                     hashes[ressource_hash] = new_hash_desc

--- a/searxstats/model.py
+++ b/searxstats/model.py
@@ -36,6 +36,7 @@ class SearxStatisticsResult:
         self.cidrs = {}
         self.forks = [
             'https://github.com/searx/searx',
+            'https://github.com/searxng/searxng',
         ]
         self.private = private
 


### PR DESCRIPTION
Display SearXNG instances as vanilla in addition to searx instances.

Always display the git URL in the HTML grade tooltip.