### PR TITLE
reference docs.searxng.org

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -123,7 +123,7 @@
           <p>See the <a href="https://github.com/searx/searx-instances">searx-instances</a> project</p>
 
           <h3>How can I install SearXNG ?</h3>
-          <p>See the <a href="https://searxng.github.io/searxng/admin/index.html">searx documentation</a></p>
+          <p>See the <a href="https://docs.searxng.org/admin/">searx documentation</a></p>
           <p>Or if you want to use docker: <a href="https://github.com/searxng/searxng-docker">https://github.com/searxng/searxng-docker</a></p>
 
           <h3>How can I use the results in another project ?</h3>


### PR DESCRIPTION
reference docs.searxng.org instead of searxng.github.io/searxng

related to https://github.com/searxng/searxng/pull/679