### PR TITLE
Add uptime from uptime.searxng.org

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -158,8 +158,8 @@
                     <th v-if="!display.comments" class="column-network">Network</th>
                     <th v-if="!display.comments" class="column-responsetime">Search response time</th>
                     <th v-if="!display.comments" class="column-responsetime">Google response time</th>
-                    <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
                     <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
+                    <th v-if="!display.comments" class="column-uptime">Uptime</th>
                     <th v-if="display.comments" class="column-comments">Comments</th>
                     <th v-if="display.comments" class="column-alternativeurls">Alternative URLs</th>
                   </tr>
@@ -180,7 +180,7 @@
                       <th v-if="!display.comments" class="column-responsetime"><div class="column-filter"><input v-model="filters.standard_search" type="checkbox" /></div></th>
                       <th v-if="!display.comments" class="column-responsetime"><div class="column-filter"><input v-model="filters.engines.google" type="checkbox" /></div></th>
                       <th v-if="!display.comments" class="column-responsetime"></th>
-                      <th v-if="!display.comments" class="column-responsetime"></th>
+                      <th v-if="!display.comments" class="column-uptime"></th>
                       <th v-if="display.comments" class="column-comments"></th>
                       <th v-if="display.comments" class="column-alternativeurls"></th>
                   </tr>
@@ -198,8 +198,8 @@
                     <td v-if="!display.comments" class="column-network"><network-name-component :value="detail.network" :cidrs="$root.cidrs"></network-name-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_go" :time_select="$root.display.time_select"></time-component></td>
-                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
+                    <td v-if="!display.comments" class="column-uptime"><uptime-component :value="detail.uptime" :url="detail.url"></uptime-component></td>
                     <td v-if="display.comments" class="column-comments">
                       <p v-for="comment in detail.comments">{{comment}}</p>
                     </td>
@@ -243,7 +243,6 @@
             <ul>
               <li>Search response time - response time of a query with the default engines.</li>
               <li>Google response time - respones time of the Google engine.</li>
-              <li>Wikipedia response time - response time of the Wikipedia engine.</li>
               <li>Initial response time - response time of the front time without prior existing connection.</li>
             </ul>
 
@@ -271,7 +270,6 @@
                       <th v-if="!display.comments" class="column-html">HTML<a class="help" href="#help-http-grade">?</a></th>
                       <th v-if="!display.comments" class="column-responsetime">Search response time</th>
                       <th v-if="!display.comments" class="column-responsetime">Google response time</th>
-                      <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
                       <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
                       <th v-if="display.comments" class="column-comments">Comments</th>
                       <th v-if="display.comments" class="column-alternativeurls">Alternative URLs</th>
@@ -284,7 +282,6 @@
                       <td v-if="!display.comments" class="column-html"><html-component :value="detail.html" :hashes="$root.hashes" :url="detail.url"></html-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_go" :time_select="$root.display.time_select"></time-component></td>
-                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="display.comments" class="column-comments">
                         <p v-for="comment in detail.comments">{{comment}}</p>

--- a/html/main.css
+++ b/html/main.css
@@ -176,6 +176,12 @@ tbody .column-network span:first-child span:first-child {
   text-align: right;
 }
 
+.column-uptime {
+  max-width: 8rem;
+  width: 8rem;
+  text-align: right;
+}
+
 .column-filter {
   display: flex;
   flex-direction: row;
@@ -230,6 +236,18 @@ tbody .column-responsetime {
   color: white;
   display: block;
   padding: 0.1rem 0.5rem 0.1rem 0.1rem;
+}
+
+.value-uptime {
+  text-align: right;
+  color: white;
+  display: block;
+  padding: 0.1rem 0.5rem 0.1rem 0.1rem;
+}
+
+.column-uptime .info-tooltip {
+  position: absolute;
+  right: 6rem;
 }
 
 .urls,

--- a/html/main.js
+++ b/html/main.js
@@ -313,6 +313,15 @@ function hslErrorPercentage(percentage) {
     return hslCss(h, s, l);
 }
 
+function hslUptimePercentage(percentage) {
+    const l = 54;
+    const value1 = Math.min(100, Math.max(90, percentage)) - 90; // from 0 to 10
+    const value = value1 * value1; // from 0 to 100
+    const h = translateValue(value, 0, 100, 0, 128, false);
+    const s = translateValue(value, 0, 100, 39, 54, true);
+    return hslCss(h, s, l);
+}
+
 function formatResponseTime(value) {
     if (typeof value === 'number') {
         return new Intl.NumberFormat('en', { maximumFractionDigits: 3, minimumFractionDigits: 3 }).format(value);
@@ -839,6 +848,42 @@ Vue.component('network-name-component', {
             return createTooltip(h, h('span', { class: 'value-network', attrs: attrs }, content), [tooltipContent]);
         }
         return undefined;
+    },
+});
+
+Vue.component('uptime-component', {
+    props: ['value', 'url'],
+    render: function (h) {
+        if (this.value != null && this.value !== undefined) {
+            const hostPath = new URL(this.url).host.replaceAll('.', '-');
+            const attrs = {
+                style: `background-color:${hslUptimePercentage(this.value.uptimeWeek)}; color:white`,
+                href: "https://uptime.searxng.org/history/" + hostPath,
+            };
+            const element = h('a', { staticClass: 'value-uptime', attrs: attrs }, Math.round(this.value.uptimeWeek) + ' %');
+            const tooltipContent = [
+                h('table', {}, [
+                    h('tr', {}, [
+                        h('td', "Today"),
+                        h('td', `${Math.round(this.value.uptimeDay)} %`)
+                    ]),
+                    h('tr', [
+                        h('td', "This week"),
+                        h('td', `${Math.round(this.value.uptimeWeek)} %`)
+                    ]),
+                    h('tr', [
+                        h('td', "This month"),
+                        h('td', `${Math.round(this.value.uptimeMonth)} %`)
+                    ]),
+                    h('tr', [
+                        h('td', "This year"),
+                        h('td', `${Math.round(this.value.uptimeYear)} %`)
+                    ]),
+                ])
+            ];
+            return createTooltip(h, element, tooltipContent);
+        }
+        return null;
     },
 });
 

--- a/searxstats/common/http.py
+++ b/searxstats/common/http.py
@@ -143,14 +143,5 @@ async def post(session, *args, **kwargs):
 
 # pylint: disable=global-variable-undefined, invalid-name
 async def initialize():
-    """
-    do the equivalent of
-    ```
-    @UseQueue(count=1, loop=loop)
-    async def request(method, *args, **kwargs):
-        ...
-    ```
-    once the `loop` value is known
-    """
     for logger_name in ('hpack.hpack', 'hpack.table', 'httpx._client'):
         logging.getLogger(logger_name).setLevel(logging.WARNING)

--- a/searxstats/fetcher/__init__.py
+++ b/searxstats/fetcher/__init__.py
@@ -12,6 +12,7 @@ from . import selfreport
 from . import cryptcheck_backend
 from . import mozillaobs
 from . import timing
+from . import uptime
 
 
 __all__ = ['FETCHERS', 'fetch']
@@ -53,6 +54,10 @@ FETCHERS = [
             'timing',
             'Test the response time 🔎🐘🔍🏁❌',
             'timing'),
+    Fetcher(uptime,
+            'uptime',
+            'Uptime from uptime.searxng.org',
+            'uptime'),
 ]
 
 

--- a/searxstats/fetcher/timing.py
+++ b/searxstats/fetcher/timing.py
@@ -170,16 +170,7 @@ async def fetch_one(instance_url: str, detail) -> dict:
                                         params={'q': 'time', **default_params},
                                         cookies=cookies, headers=DEFAULT_HEADERS)
 
-            # check the wikipedia engine
-            print('🐘 ' + instance_url)
-            await request_stat_with_log(search_url, timing, 'search_wp',
-                                        client, instance_url,
-                                        2, 60, 160, check_result.check_wikipedia_result,
-                                        params={'q': '!wp time', **default_params},
-                                        cookies=cookies, headers=DEFAULT_HEADERS)
-
             # check the google engine
-            # may include google results too, so wikipedia engine check before
             print('🔍 ' + instance_url)
             await request_stat_with_log(search_url, timing, 'search_go',
                                         client, instance_url,

--- a/searxstats/fetcher/uptime.py
+++ b/searxstats/fetcher/uptime.py
@@ -1,0 +1,31 @@
+# pylint: disable=invalid-name
+from searxstats.common.http import get, new_client, NetworkType
+from searxstats.model import SearxStatisticsResult
+
+UPTIME_URL = 'https://raw.githubusercontent.com/searxng/searx-instances-uptime/master/history/summary.json'
+
+
+def percent_str_to_float(s):
+    return float(s.replace('%', ''))
+
+
+# pylint: disable=unsubscriptable-object, unsupported-delete-operation, unsupported-assignment-operation
+# pylint thinks that ressource_desc is None
+async def fetch(searx_stats_result: SearxStatisticsResult):
+    async with new_client(network_type=NetworkType.NORMAL) as session:
+        response, error = await get(session, UPTIME_URL)
+    if error:
+        print(error)
+        return
+    uptime_list = response.json()
+    uptimes = {}
+    for instance in uptime_list:
+        uptimes[instance['url'] + '/'] = {
+            'uptimeDay': percent_str_to_float(instance['uptimeDay']),
+            'uptimeWeek': percent_str_to_float(instance['uptimeWeek']),
+            'uptimeMonth': percent_str_to_float(instance['uptimeMonth']),
+            'uptimeYear': percent_str_to_float(instance['uptimeYear']),
+        }
+
+    for url, detail in searx_stats_result.iter_instances(valid_or_private=True):
+        detail['uptime'] = uptimes.get(url)


### PR DESCRIPTION
Forget the empty columns, just look at the last columns:
* the wikipedia response time is removed
* the weekly uptime from uptime.searxng.org
* 
![image](https://user-images.githubusercontent.com/1594191/192138216-399da559-b130-41ff-a332-71fe776add54.png)
