### PR TITLE
[ASN] remove AS16509 from the "ASN bad for privacy" list

### DIFF
--- a/searxstats/data/asn.py
+++ b/searxstats/data/asn.py
@@ -69,7 +69,7 @@ ASN_PRIVACY = {
     "264167": AsnPrivacy.BAD,
     "19047": AsnPrivacy.BAD,
     "17493": AsnPrivacy.BAD,
-    "16509": AsnPrivacy.BAD,
+    # "16509": AsnPrivacy.BAD,
     "14618": AsnPrivacy.BAD,
     "135630": AsnPrivacy.BAD,
     "10124": AsnPrivacy.BAD,


### PR DESCRIPTION
AS16509 offer CDN services AND normal server hosting, by example searxng.nicfab.eu [1].

Related: https://github.com/searxng/searx-space/issues/129
Suggested-by: @nicfab [2]
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>

[1] https://ipinfo.io/18.102.75.27
[2] https://github.com/searxng/searx-space/issues/129#issuecomment-1430971842