### PR TITLE
[fix] oscar theme is not supported by origin SearXNG / use simple theme

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -473,7 +473,7 @@ Vue.component('engine-component', {
         if (this.instance !== undefined && this.engine !== undefined) {
             const engine = this.instance.engines[this.engine];
             if (engine !== undefined) {
-                const href= this.instance.url + 'search?q=!' + this.engine.replace(' ', '_') + ' time&theme=oscar&language=en';
+                const href= this.instance.url + 'search?q=!' + this.engine.replace(' ', '_') + ' time&language=en';
 
                 let text;
                 let working_engine = false;

--- a/searxstats/config.py
+++ b/searxstats/config.py
@@ -30,8 +30,7 @@ DEFAULT_COOKIES = {
     'image_proxy': '0',
     'method': 'GET',
     'safesearch': '0',
-    'theme': 'oscar',
-    'oscar-style': 'logicodev'
+    'theme': 'simple',
 }
 
 # Default working directory


### PR DESCRIPTION
Only a few instances still support the oscar theme (searx.be is the only one I know).

----

**Hint**: this PR does not remove oscar from the timings:

https://github.com/searxng/searx-space/blob/b5f0d0cc4b0f6aa29a8d8c7e70a9f654efbe5d7c/searxstats/fetcher/timing.py#L64-L77

https://github.com/searxng/searx-space/blob/b5f0d0cc4b0f6aa29a8d8c7e70a9f654efbe5d7c/searxstats/fetcher/timing.py#L160-L162


