### PR TITLE
Make the public_instance settings mandatory

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -23,7 +23,8 @@ const COMMON_ERROR_MESSAGE = {
     '[Errno -2] Name does not resolve': 'Unknown host',
     'certificate verify failed': 'Certificate verify failed',
     'hostname \'': 'Hostname doesn\'t match certificate',
-    'Tor Error: ': 'Tor Error'
+    'Tor Error: ': 'Tor Error',
+    'Not configured as a public instance': 'Not configured as a public instance',
 };
 
 const SORT_CRITERIAS = [

--- a/searxstats/fetcher/basic.py
+++ b/searxstats/fetcher/basic.py
@@ -74,6 +74,12 @@ async def set_searx_version(detail, git_url, session, response_url, response):
         detail['version'] = version
         detail['contact_url'] = config.get('brand', {}).get('CONTACT_URL')
         detail['docs_url'] = await resolve_https_redirect(session, doc_url)
+        detail['public_instance'] = config.get('public_instance', False)
+        detail['limiter'] = config.get('limiter', {
+            'botdetection.ip_limit.link_token':	False,
+            'botdetection.ip_lists.pass_searxng_org': False,
+            'enabled': False,
+        })
     if git_url:
         git_url = await resolve_https_redirect(session, git_url)
     else:
@@ -133,6 +139,8 @@ async def fetch_one(instance_url: str, git_url: str, private: bool) -> dict:
     if error is not None:
         detail['http']['error'] = error
         detail['error'] = error
+    elif not detail.get('public_instance', False):
+        detail['error'] = 'Not configured as a public instance'
 
     return instance_url, detail
 


### PR DESCRIPTION
Instances without this settings are displayed in the "Offline & error" tab.

For reference: 
* https://gist.github.com/unixfox/4e22730769540fe5b9f1943a86439761
* https://github.com/searxng/searxng/pull/2848

Screenshot of the "Offline & error" tab:
![image](https://github.com/searxng/searx-space/assets/1594191/7fa7a9d8-181b-4d97-964b-78d1bc509960)

To merge on December 1st.
