### PR TITLE
fix: drop archived httpobs for mdm api

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,5 +9,4 @@ export PATH=/opt/firefox:$PATH
 
 /usr/bin/tor -f /usr/local/searxstats/torrc
 
-pip3 install --break-system-packages --upgrade -r requirements-update.txt
 python3 -msearxstats $@

--- a/html/index.html
+++ b/html/index.html
@@ -222,8 +222,8 @@
             <p>Grade from <a href="https://cryptcheck.fr/">cryptcheck.fr</a> (source code: <a href="https://github.com/aeris/cryptcheck">aeris/cryptcheck</a> and <a href="https://github.com/dalf/cryptcheck-backend">dalf/cryptcheck-backend</a>).</p>
 
             <h4 id="help-csp-grade">CSP grade</h4>
-            <p>Grade from <a href="https://github.com/dalf/http-observatory">dalf/http-observatory</a> updated fork of <a href="https://observatory.mozilla.org/faq.html">Observatory by mozilla</a>.
-            <p>Note: The grade shown here might be different from observatory.mozilla.org: searx.space checks the full SearXNG URL, observatory.mozilla.org checks the root path.</p>
+            <p>Grade from the <a href="https://developer.mozilla.org/en-US/observatory">MDN HTTP Observatory</a>
+            (source code: <a href="https://github.com/mdn/mdn-http-observatory">mdn/mdn-http-observatory</a>).</p>
 
             <h4 id="help-html-grade">HTML grade</h4>
             <p>When the page is loaded by Firefox, are the scripts well-known ?</p>

--- a/html/main.js
+++ b/html/main.js
@@ -697,16 +697,17 @@ Vue.component('csp-component', {
     props: ['value'],
     render: function (h) {
         if (this.value != null && this.value !== undefined) {
-            const { grade, gradeUrl, version } = this.value;
+            const { grade, gradeUrl, score } = this.value;
             if (grade != null) {
-                return h('a', {
-                    class: 'value-tls',
-                    attrs: {
-                        href: gradeUrl,
-                        title: version,
-                        style: `background-color:${hslGrade(grade)}`,
-                    },
-                }, grade);
+                return createTooltip(h,
+                    h('a', {
+                        class: 'value-tls',
+                        attrs: {
+                            href: gradeUrl,
+                            style: `background-color:${hslGrade(grade)}`,
+                        },
+                    }, grade),
+                    score != null ? [String(score)] : []);
             }
         }
         return undefined;

--- a/requirements-update.txt
+++ b/requirements-update.txt
@@ -1,1 +1,0 @@
-httpobs @ git+https://github.com/dalf/http-observatory@master#egg=httpobs

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,4 @@ pyyaml==6.0.3
 GitPython==3.1.52
 sqlalchemy==2.0.36
 rfc3986==2.0.0
-httpobs @ git+https://github.com/dalf/http-observatory@master#egg=httpobs
-requests==2.33.0
-urllib3<3
-beautifulsoup4==4.14.2
-publicsuffixlist==1.0.2.20260716
-celery==5.2.7
 geoip2==5.1.0

--- a/searxstats/fetcher/mozillaobs.py
+++ b/searxstats/fetcher/mozillaobs.py
@@ -1,9 +1,8 @@
 # pylint: disable=invalid-name
-from urllib.parse import urlparse
-from httpobs.scanner.local import scan
-from searxstats.config import DEFAULT_HEADERS
+import httpx
+
 from searxstats.common.utils import exception_to_str
-from searxstats.common.http import NetworkType
+from searxstats.common.http import get_host, NetworkType
 from searxstats.common.memoize import MemoizeToDisk
 from searxstats.model import create_fetch
 
@@ -11,24 +10,36 @@ from searxstats.model import create_fetch
 USER_ENDPOINT = 'https://observatory.mozilla.org/analyze/{0}'
 
 
-@MemoizeToDisk()
+def validate_result(result):
+    if isinstance(result, tuple):
+        return result[0] is not None and result[0] != ''
+    return True
+
+
+@MemoizeToDisk(validate_result=validate_result, expire_time=24*3600)
 def analyze(url: str):
-    parsed_url = urlparse(url)
-    grade_url = USER_ENDPOINT.format(parsed_url.hostname)
+    host = get_host(url)
+    grade_url = USER_ENDPOINT.format(host)
     grade = None
+    score = None
     try:
-        result = scan(str(parsed_url.hostname), path=str(parsed_url.path), headers=DEFAULT_HEADERS)
-        grade = result.get('scan', {}).get('grade', None)
+        response = httpx.post(
+            'https://observatory-api.mdn.mozilla.net/api/v2/scan?host={0}'.format(host),
+            timeout=60)
+        if response.status_code == 200:
+            payload = response.json()
+            if not payload.get('error'):
+                grade = payload.get('grade')
+                score = payload.get('score')
     except Exception as ex:
         print(url, exception_to_str(ex))
-        grade = None
-    return (grade, grade_url)
+    return (grade, grade_url, score)
 
 
 def fetch_one(url: str) -> dict:
-    grade, grade_url = analyze(url)
+    grade, grade_url, score = analyze(url)
     print('📄 {0:30} {1}'.format(url, grade))
-    return {'grade': grade, 'gradeUrl': grade_url}
+    return {'grade': grade, 'gradeUrl': grade_url, 'score': score}
 
 
 fetch = create_fetch(['http'], fetch_one, valid_or_private=True, network_type=NetworkType.NORMAL, limit=4)


### PR DESCRIPTION
- Use the observatory API instead of the archived local version of httpobs
- Drop unused httpobs deps (quite a few!)
- While I was here, also decided to show score on hover because it looks cool:
<img width="774" height="278" alt="Screenshot" src="https://github.com/user-attachments/assets/97a2362e-11ef-42ff-9cdf-1af9d76d8b4b" />

Closes https://github.com/searxng/searx-space/issues/187