### PR TITLE
feat: add contact url

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -193,7 +193,7 @@
                 </thead>
                 <tbody>
                   <tr v-for="detail in instances_filtered">
-                    <td class="column-url"><url-component :url="detail.url" :alternativeurls="detail.alternativeUrls" :comments="detail.comments" :git_url="detail.git_url"></url-component></td>
+                    <td class="column-url"><url-component :url="detail.url" :alternativeurls="detail.alternativeUrls" :comments="detail.comments" :git_url="detail.git_url" :contact_url="detail.contact_url"></url-component></td>
                     <td class="column-version">{{detail.version}}</td>
                     <td v-if="!display.comments" class="column-tls"><tls-component :value="detail.tls"></tls-component></td>
                     <td v-if="!display.comments" class="column-csp"><csp-component :value="detail.http"></csp-component></td>
@@ -385,7 +385,7 @@
                   </thead>
                   <tbody>
                       <tr v-for="detail in instances_filtered" v-if="detail.engines">
-                          <td class="column-url"><url-component :url="detail.url" :alternativeurls="detail.alternativeUrls" :comments="detail.comments" :git_url="detail.git_url"></url-component></td>
+                          <td class="column-url"><url-component :url="detail.url" :alternativeurls="detail.alternativeUrls" :comments="detail.comments" :git_url="detail.git_url" :contact_url="detail.contact_url"></url-component></td>
                           <td class="engine-status" v-for="engine in selected_engines"><engine-component :instance='detail' :engine='engine' :engine_errors='$root.engine_errors'></engine-component></td>
                       </tr>
                   </tbody>

--- a/html/main.js
+++ b/html/main.js
@@ -362,7 +362,7 @@ function tooltip_add_timing(h, tooltip_lines, timing, time_label) {
 }
 
 Vue.component('url-component', {
-    props: ['url', 'alternativeurls', 'comments', 'git_url'],
+    props: ['url', 'alternativeurls', 'comments', 'git_url', 'contact_url'],
     render: function(h) {
         if (this.url != null && this.url !== undefined) {
             let tooltipLines = [];
@@ -386,10 +386,21 @@ Vue.component('url-component', {
                     ]));
                 }
             }
-            tooltipLines.push(h('tr', [
-                h('td', 'Git URL'),
-                h('td', [ h('a', { attrs: { href: this.git_url } }, this.git_url) ]),
-            ]));
+            if (this.git_url) {
+                tooltipLines.push(h('tr', [
+                    h('td', 'Git URL'),
+                    h('td', [ h('a', { attrs: { href: this.git_url } }, this.git_url) ]),
+                ]));
+            }
+            if (this.contact_url) {
+                const contactLabel = this.contact_url.toLowerCase().startsWith('mailto:')
+                    ? this.contact_url.slice(7)
+                    : this.contact_url;
+                tooltipLines.push(h('tr', [
+                    h('td', 'Contact'),
+                    h('td', [ h('a', { attrs: { href: this.contact_url } }, contactLabel) ]),
+                ]));
+            }
             const ahrefElement = h('a', { attrs: {  href: this.url } }, this.url);
             if (tooltipLines.length > 0) {
                 return createTooltip(h,


### PR DESCRIPTION
Adds contact url to the frontend (already in the json)

<img width="534" height="460" alt="Screenshot" src="https://github.com/user-attachments/assets/0bba0195-3e60-4265-b800-fc398d275bc9" />

For mailto:foo@bar.com links, the mailto: is stripped out of the preview to just show foo@bar.com
<img width="389" height="111" alt="Screenshot" src="https://github.com/user-attachments/assets/d4bf2845-4fe9-463a-8695-6258addbd13f" />

Closes https://github.com/searxng/searx-space/issues/59